### PR TITLE
Fix thumbnail error in trimming editor

### DIFF
--- a/lib/src/thumbnail_viewer.dart
+++ b/lib/src/thumbnail_viewer.dart
@@ -62,10 +62,7 @@ class ThumbnailViewer extends StatelessWidget {
                 return Container(
                   height: thumbnailHeight,
                   width: thumbnailHeight,
-                  child: Image(
-                    image: MemoryImage(_imageBytes[index]),
-                    fit: fit,
-                  ),
+                  child: _image(_imageBytes, index),
                 );
               });
         } else {
@@ -77,5 +74,16 @@ class ThumbnailViewer extends StatelessWidget {
         }
       },
     );
+  }
+
+  Widget _image(List<Uint8List> imageBytes, int index) {
+    try {
+      return Image(
+        image: MemoryImage(imageBytes[index]),
+        fit: fit,
+      );
+    } catch (e) {
+      return Container();
+    }
   }
 }


### PR DESCRIPTION
For short videos from in-app camera, we've experienced this bug.
![Image from iOS](https://user-images.githubusercontent.com/2264901/101904019-7ef46f80-3bb5-11eb-9ba0-1b4b340b0808.png)

https://vid-app.slack.com/archives/C01BML66RQF/p1607684233194500
