### PR TITLE
Refresh frames when dragging trimming handles

### DIFF
--- a/lib/src/trim_editor.dart
+++ b/lib/src/trim_editor.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -232,6 +233,8 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
   AnimationController _animationController;
   Tween<double> _linearTween;
 
+  final _refreshVideoDuration = Duration(milliseconds: 50);
+
   Future<void> _initializeVideoController() async {
     if (_videoFile != null) {
       videoPlayerController.addListener(() {
@@ -330,7 +333,7 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
         widget.onChangeEnd(_videoEndPos);
       });
       await videoPlayerController.pause();
-      await videoPlayerController.seekTo(Duration(milliseconds: _videoEndPos.toInt()));
+      await videoPlayerController.seekTo(Duration(milliseconds: _videoEndPos.toInt()) - _refreshVideoDuration);
       _linearTween.end = _endPos.dx;
       _animationController.duration = Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
       _animationController.reset();
@@ -435,10 +438,11 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
           }
         }
       },
-      onHorizontalDragEnd: (DragEndDetails details) {
+      onHorizontalDragEnd: (DragEndDetails details) async {
         setState(() {
           _circleSize = widget.circleSize;
         });
+        await _refreshVideoIfNeeded();
       },
       onHorizontalDragUpdate: (DragUpdateDetails details) {
         _circleSize = widget.circleSizeOnDrag;
@@ -515,5 +519,14 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
         ),
       ),
     );
+  }
+
+  _refreshVideoIfNeeded() async {
+    if (Platform.isIOS) {
+      await videoPlayerController.play();
+      Timer(_refreshVideoDuration, () {
+        videoPlayerController.pause();
+      });
+    }
   }
 }


### PR DESCRIPTION
Before (not refreshed):
![before](https://user-images.githubusercontent.com/2264901/102816488-61ea4880-43ce-11eb-981f-5c47af4a15d3.gif)

After (refreshed)
![after](https://user-images.githubusercontent.com/2264901/102816507-6c0c4700-43ce-11eb-9f5a-4530e8f38d8e.gif)
