### PR TITLE
Fix play when predefined start

### DIFF
--- a/example/lib/trimmer_view.dart
+++ b/example/lib/trimmer_view.dart
@@ -82,8 +82,8 @@ class _TrimmerViewState extends State<TrimmerView> {
                   child: TrimEditor(
                     viewerHeight: 50.0,
                     viewerWidth: MediaQuery.of(context).size.width - 100,
-                    initStartDuration: Duration(seconds: 1),
-                    initEndDuration: Duration(seconds: 3),
+                    initStartDuration: Duration(seconds: 5),
+                    initEndDuration: Duration(seconds: 6),
                     maxVideoLength: Duration(seconds: 4),
                     minVideoLength: Duration(seconds: 1),
                     onChangeStart: (value) {

--- a/lib/src/trim_editor.dart
+++ b/lib/src/trim_editor.dart
@@ -379,6 +379,7 @@ class _TrimEditorState extends State<TrimEditor> with TickerProviderStateMixin {
       _startPos = Offset(_initStartPosition, 0);
     }
     _refreshStart();
+    videoPlayerController.seekTo(Duration(milliseconds: _videoStartPos.toInt()));
 
     double endOffsetX;
 


### PR DESCRIPTION
When running trimmer with predefined values, a video was played from the beginning, instead of from the predefined start.